### PR TITLE
Update for Piwigo v11

### DIFF
--- a/include/events_admin.inc.php
+++ b/include/events_admin.inc.php
@@ -29,86 +29,14 @@ function typetags_admin()
 
   load_language('plugin.lang', TYPETAGS_PATH);
 
-  // save
-  if (isset($_POST['typetags_submit']))
+  // add tag colors to template
+  $query = 'SELECT * FROM ' . TYPETAGS_TABLE . ' ORDER BY name;';
+  $result = pwg_query($query);
+
+  while ($row = pwg_db_fetch_assoc($result))
   {
-    if ($_POST['mode'] == 'global')
-    {
-      $query = '
-UPDATE ' . TAGS_TABLE . '
-  SET id_typetags = ' . ($_POST['tag_color-all']!=-1 ? get_typetag_id($_POST['tag_color-all']) : 'NULL') . '
-  WHERE id IN ('.$_POST['edit_list'].')
-;';
-      pwg_query($query);
-    }
-    else
-    {
-      $updates = $deletes = array();
-
-      foreach (explode(',', $_POST['edit_list']) as $tag_id)
-      {
-        if ($_POST['tag_color-'.$tag_id]!=-1)
-        {
-          $updates[] = array(
-            'id' => $tag_id,
-            'id_typetags' => get_typetag_id($_POST['tag_color-'.$tag_id]),
-            );
-        }
-        else
-        {
-          $deletes[] = $tag_id;
-        }
-      }
-
-      mass_updates(
-        TAGS_TABLE,
-        array('primary' => array('id'), 'update' => array('id_typetags')),
-        $updates
-        );
-
-      if (!empty($deletes))
-      {
-        $query = '
-UPDATE ' . TAGS_TABLE . '
-  SET id_typetags = NULL
-  WHERE id IN('. implode(',', $deletes) .')
-;';
-        pwg_query($query);
-      }
-    }
-  }
-
-  // enter edit
-  if (isset($_POST['typetags']) and isset($_POST['tags']))
-  {
-    $template->assign('TYPETAGS_LIST', implode(',', $_POST['tags']));
-
-    $query = '
-SELECT
-    t.id,
-    t.name,
-    id_typetags,
-    color
-  FROM ' . TAGS_TABLE . ' AS t
-    LEFT JOIN ' . TYPETAGS_TABLE . ' AS tt
-    ON t.id_typetags = tt.id
-  WHERE t.id IN ('.implode(',', $_POST['tags']).')
-;';
-    $result = pwg_query($query);
-    while ($row = pwg_db_fetch_assoc($result))
-    {
-      $row['color_text'] = get_color_text($row['color']);
-      $template->append('tags', $row);
-    }
-
-    $query = 'SELECT * FROM ' . TYPETAGS_TABLE . ' ORDER BY name;';
-    $result = pwg_query($query);
-
-    while ($row = pwg_db_fetch_assoc($result))
-    {
-      $row['color_text'] = get_color_text($row['color']);
-      $template->append('typetags', $row);
-    }
+    $row['color_text'] = get_color_text($row['color']);
+    $template->append('typetags', $row);
   }
 
   $query = '
@@ -137,17 +65,12 @@ SELECT
 function typetags_admin_prefilter($content)
 {
   // add form part
-  $search[0] = '<form action="{$F_ACTION}" method="post">';
-  $replace[0] = $search[0] . file_get_contents(realpath(TYPETAGS_PATH . 'template/tags.tpl'));
+  $search[0] = '<div class="titrePage">';
+  $replace[0] = file_get_contents(realpath(TYPETAGS_PATH . 'template/tags.tpl')) . $search[0];
 
-  // hide other parts of the page when editing tag colors
-  $search[1] = '!isset($MERGE_TAGS_LIST)';
-  $replace[1] = $search[1].' and !isset($TYPETAGS_LIST)';
-
-  // color on main list
-  $search[2] = '<input type="checkbox" name="tags[]" value="{$tag.id}">
-          {$tag.name}';
-  $replace[2] = '<input type="checkbox" name="tags[]" value="{$tag.id}"> <span style="color:{$tags_color[$tag.id].color};">{$tag.name}</span>';
+  // add button
+  $search[1] = '<button id="DeleteSelectionMode"';
+  $replace[1] = '<button id="TypetagsChangeColor" class="icon-brush">{"Couleur"|translate}</button>'.$search[1];
 
   return str_replace($search, $replace, $content);
 }

--- a/language/en_UK/plugin.lang.php
+++ b/language/en_UK/plugin.lang.php
@@ -18,5 +18,6 @@ $lang['Only on tags page'] = 'Only on tags page';
 $lang['Everywhere'] = 'Everywhere';
 $lang['New color'] = 'New color';
 $lang['You must fill all fields (name and color)'] = 'You must fill all fields (name and color)';
+$lang['Go to <a href="%s">plugin page</a> to edit colors'] = 'Go to <a href="%s">plugin page</a> to edit colors';
 
 ?>

--- a/language/fr_FR/plugin.lang.php
+++ b/language/fr_FR/plugin.lang.php
@@ -10,7 +10,7 @@ $lang['Edit color'] = 'Editer une couleur';
 $lang['Go to <a href="%s">Photos/Tags</a> to manage associations.'] = 'Allez sur <a href="%s">Photos/Tags</a> pour gérer les associations.';
 $lang['Invalid color'] = 'Couleur invalide';
 $lang['Manage colors'] = 'Gérer les couleurs';
-$lang['This name is already used'] = 'The nom est déjà utilisé';
+$lang['This name is already used'] = 'Le nom est déjà utilisé';
 $lang['Set a different color for each tag'] = 'Appliquer une couleur différente à chaque tag';
 $lang['Set tags color'] = 'Changer la couleur des tags';
 $lang['Display colored tags'] = 'Afficher les tags colorés';
@@ -18,5 +18,6 @@ $lang['Only on tags page'] = 'Uniquement sur la liste des tags';
 $lang['Everywhere'] = 'Partout';
 $lang['New color'] = 'Nouvelle couleur';
 $lang['You must fill all fields (name and color)'] = 'Vous devez remplir tous les champs (nom et couleur)';
+$lang['Go to <a href="%s">plugin page</a> to edit colors'] = 'Allez sur <a href="%s">la page du plugin</a> pour éditer les couleurs';
 
 ?>

--- a/main.inc.php
+++ b/main.inc.php
@@ -28,7 +28,7 @@ define('TYPETAGS_TABLE' , $prefixeTable . 'typetags');
 define('TYPETAGS_ADMIN',  get_root_url().'admin.php?page=plugin-typetags');
 
 include_once(TYPETAGS_PATH . 'include/events_public.inc.php');
-
+include_once(TYPETAGS_PATH . 'include/functions.inc.php');
 
 $conf['TypeTags'] = safe_unserialize($conf['TypeTags']);
 
@@ -59,4 +59,107 @@ if (defined('IN_ADMIN'))
   add_event_handler('loc_begin_admin_page', 'typetags_admin');
 
   include_once(TYPETAGS_PATH . 'include/events_admin.inc.php');
+}
+
+// add api/service methods
+add_event_handler('ws_add_methods', 'typetags_add_methods');
+
+function typetags_add_methods($arr) 
+{
+  $service = &$arr[0];
+
+  $service->addMethod(
+    'typetags.tags.setType',
+    'ws_typetags_tags_setType',
+    array(
+      'tag_id' => array('type' => WS_TYPE_ID, 'flags'=>WS_PARAM_FORCE_ARRAY),
+      'typetag_id' => array('info' => 'Zero (0) for remove color')
+      ),
+    'Set/remove color for a list of tags',
+    null,
+    array('admin_only'=>true)
+  );
+
+  $service->addMethod(
+    'typetags.type.add',
+    'ws_typetags_type_add',
+    array(
+      'typetag_name' => array(),
+      'typetag_color' => array('info' => 'In format RRVVBB (Example : FF0000 for red)')
+      ),
+    'Create a tag color'
+    );
+}
+
+
+/**
+ * API method
+ * Set a color for tags
+ * @param mixed[] $params
+ *    @option int[] tag_id
+ *    @option int typetag_id
+ */
+function ws_typetags_tags_setType($params, &$service) 
+{
+$query = '
+UPDATE ' . TAGS_TABLE . '
+  SET id_typetags = ' . ($params['typetag_id']!=0 ? $params['typetag_id'] : 'NULL') . '
+  WHERE id IN ('.implode(',', $params['tag_id']).')
+;';
+  pwg_query($query);
+}
+
+/**
+ * API method
+ * Create a new type of tag
+ * @param mixed[] $params
+ *    @option string typetag_name
+ *    @option string typetag_color
+ */
+function ws_typetags_type_add($params, &$service) 
+{
+  $name = $params['typetag_name'];
+  $color = '#' . $params['typetag_color'];
+
+  // does the tag already exists?
+  $query = '
+SELECT id
+  FROM ' . TYPETAGS_TABLE . '
+  WHERE name = "' . pwg_db_real_escape_string($name) . '"
+';
+
+  if (pwg_db_num_rows(pwg_query($query)))
+  {
+    return new PwgError(WS_ERR_INVALID_PARAM, l10n('This name is already used'));
+  }
+  else if ( ($color = check_color($color)) === false )
+  {
+    return new PwgError(WS_ERR_INVALID_PARAM, l10n('Invalid color'));
+  }
+  else
+  {
+    single_insert(
+      TYPETAGS_TABLE, 
+      array(
+        "name" => pwg_db_real_escape_string($name),
+        "color" => $color,
+      )
+    );
+
+    $id = pwg_db_insert_id(IMAGES_TABLE);
+
+    if (pwg_query($query)) 
+    {
+      return array(
+        'id' => $id,
+        'color' => $color,
+        'color_text' => get_color_text($color),
+        'name' => $name,
+      );
+    } 
+    else 
+    {
+      return false;
+    };
+  }
 }

--- a/template/style.css
+++ b/template/style.css
@@ -1,17 +1,3 @@
-#colorpicker-container {
-  float:right;
-  width:450px;
-  margin:auto;
-}
-#colorpicker-container .error {
-  color:#e00;
-  font-weight:bold;
-}
-#colorpicker-container .info {
-  color:#090;
-  font-style:italic;
-}
-
 #colorpicker {
   float:left;
   margin-right:15px;
@@ -26,4 +12,219 @@
   float:right;
   margin-left:-37px;
   margin-top:2px;
+}
+
+.typetag-color-sample {
+  width: 20px;
+  height: 20px;
+  border-radius: 20px;
+  margin-right: 8px;
+}
+
+/* The style of the popin is the same as the popin in the user manager (button, message, title...) */
+
+#TypetagsOption .popin-title .icon {
+  padding: 7px;
+  color: rgb(44,132,195);
+  background-color: #CDE9FD;
+  border-radius: 25px;
+  font-size: 15px;
+}
+
+#TypetagsOption .popin-title .title {
+  font-weight: 700;
+  font-size: 15px;
+}
+
+#TypetagsOption .typetags-tags-container, #TypetagsOption .typetags-tags, #TypetagsOption .typetags-tag {
+  display: flex;
+  align-items: center;
+}
+
+#TypetagsOption .typetags-tags-container .icon-tags, #TypetagsOption .typetags-tags-container .icon-plus-circled {
+  font-size: 20px;
+}
+
+#TypetagsOption .typetags-main-container {
+  display: grid;
+  grid-template-columns: 50% 50%;
+}
+
+#TypetagsOption .typetags-main-container > div:first-child {padding-left: 0px;}
+
+#TypetagsOption .typetags-main-container > div {padding: 0 20px;}
+
+#TypetagsOption .typetags-main-container > div:last-child {padding-right: 0px;}
+
+#TypetagsOption .typetags-main-container > div > p:first-child {
+  font-size: 15px;
+  font-weight: bold;
+}
+
+#TypetagsOption .color-option-container {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+#TypetagsOption .color-option label {
+  padding: 5px 10px;
+  border: 2px solid white;
+  display: flex;
+  align-items: center;
+  width: min-content;
+  border-radius: 40px;
+  margin: 5px;
+} 
+
+#TypetagsOption .color-option label {
+  display: flex;
+  align-items: center;
+}
+
+#TypetagsOption .color-option label .color-name {
+  white-space: nowrap;
+}
+
+#TypetagsOption .color-sample {
+  width: 20px;
+  height: 20px;
+  display: block;
+  border-radius: 20px;
+  margin-right: 5px;
+  position: relative;
+}
+
+#TypetagsOption .color-sample i {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0;
+}
+
+#TypetagsOption input:not(:checked) + label {
+  background: none !important;
+}
+
+#TypetagsOption input:not(:checked) + label .color-name{
+  color: inherit !important; /* bu default, take the color of the theme */
+}
+
+#TypetagsOption input:checked + label .color-sample{
+  background: #fff !important;
+}
+
+#TypetagsOption input:checked + label .color-sample i {
+  opacity: 1;
+}
+
+#TypetagsOption input:checked + label {
+  opacity: 1;
+}
+
+#TypetagsOption .typetag-color-create-container{
+  display: flex;
+}
+
+#TypetagsOption .typetag-color-create-form{
+  display: flex;
+  flex-direction: column;
+  align-items: baseline;
+}
+
+#TypetagsOption .typetags-input-container p {
+  color: #A4A4A4;
+  font-weight: bold;
+  font-size: 1.1em;
+  margin-bottom: 5px;
+}
+
+#TypetagsOption .typetags-input-container input {
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 1.1em;
+  padding: 8px 16px;
+  border: none;
+}
+
+#TypetagsOption .typetags-create-actions {
+  margin-top: 20px;
+  display: flex;
+  align-items: center;
+}
+
+#TypetagsOption .typetags-actions {
+  display: flex;
+  margin-top: 15px;
+}
+
+#TypetagsOption .typetag-button { /* Based on the style of the button in the user manager popin */
+  cursor: pointer;
+  padding: 10px 20px;
+  font-size: 1.1em;
+  font-weight: bold;
+  background-color: #ffa744;
+  color: #3c3c3c;
+  position: relative;
+  margin-right: 10px;
+  white-space: nowrap;
+}
+
+#TypetagsOption .typetag-button:hover {
+  background-color: #ff7700;
+}
+
+#TypetagsOption .typetag-button.disabled, #TypetagsOption .typetag-button.disabled:hover {
+  cursor: initial;
+  background-color: #777;
+}
+
+#TypetagsOption .typetag-button.loading {
+  color: #00000000;
+}
+
+#TypetagsOption .typetag-button i {
+  position:absolute;
+  top: calc(50% - 10px);
+  left: calc(50% - 5px);
+  opacity: 0 ;
+}
+
+#TypetagsOption .typetag-button.loading i {
+  opacity: 1;
+  color: black;
+}
+
+#TypetagsOption .close-button {
+  cursor: pointer;
+  opacity: 0.8;
+  padding: 10px 20px;
+  font-size: 1.1em;
+  font-weight: bold;
+}
+
+#TypetagsOption .close-button:hover {
+  opacity: 1;
+}
+
+#TypetagsOption .typetag-error {
+  padding: 10px;
+  display: none;
+  background-color: #f5c2c2;
+  color: rgb(170, 0, 0);
+  border-left: 2px solid #ff0000;
+}
+
+#TypetagsOption .typetag-message {
+  padding: 10px;
+  display: none;
+  background-color: #c2f5c2;
+  color: #0a0;
+  border-left: 2px solid #00FF00;
+}
+
+#TypetagsOption .typetags-info {
+  position: absolute;
+  right: 30px;
+  bottom: 30px;
 }

--- a/template/tags.js
+++ b/template/tags.js
@@ -1,0 +1,260 @@
+// init colorpicker
+$('#colorpicker').farbtastic('#TypetagColor');
+
+let typetagsHasValidate = false; // if the color has changed, save it for deselect tags when the popin is closed
+
+// Tag selected for the color change
+let selectedForTypetags = [];
+
+// change color for the given id list on the page
+async function updateTagsColor(tagIds) {
+    for (let i = 0; i < tagIds.length; i++) {
+        let tagId = tagIds[i];
+        await updateTagColor(tagId);
+    }
+}
+
+// change color of one tag on the page
+async function updateTagColor(tagId) {
+    let colorSample = $('.tag-box[data-id=' + tagId + '] .typetag-color-sample');
+    if (tagColor[tagId].id_typetags != null) {
+        if (colorSample.length == 0) {
+            colorSample = $('<span class="typetag-color-sample tiptip"></span>');
+            $('.tag-box[data-id=' + tagId + ']').prepend(colorSample);
+        }
+        colorSample.prop('title', typeOfTags[tagColor[tagId].id_typetags].name);
+        colorSample.css('background', tagColor[tagId].color);
+    } else if (colorSample.length = !0) {
+        colorSample.remove();
+    }
+}
+
+// get tag displayed on page
+function getIdsOnPage() {return $('.tag-box').map((n, el) => parseInt(el.getAttribute('data-id'))) }
+
+// get tag displayed and selected on page
+function getIdsSelectedOnPage() { return $('.tag-box[data-selected=1]').map((n, el) => el.getAttribute('data-id'))}
+
+// show tags color at the load of the page
+updateTagsColor(getIdsOnPage());
+
+// when we click on the "color" button, show the popin and display selected tag in it
+$('#TypetagsChangeColor').click(() => {
+    selectedForTypetags = selected;
+
+    showTypetagsPopin();
+});
+
+function showTypetagsPopin() {
+    $('#TypetagsOption .typetags-tags-container').html('');
+    const container = $('#TypetagsOption .typetags-tags-container');
+    const idsOnDisplay = getIdsSelectedOnPage();
+    const numberDisplayed = Math.min(idsOnDisplay.length, 10);
+
+    for (let i = 0; i < numberDisplayed; i++) {
+        const id = idsOnDisplay[i];
+        const name = $('.tag-box[data-id=' + id + '] .tag-name').html();
+        const tagNode = $('<span class="typetags-tag"><i class="icon-tags"></i>' + name + '</span>');
+        container.append(tagNode);
+        if (id in tagColor)
+            tagNode.find('i').css('color', tagColor[id].color)
+        else // if the tag just created
+            tagColor[id] = { id_typetags: null, color: null }; // create an entry in tagColor
+    }
+
+    if (selectedForTypetags.length > numberDisplayed) {
+        container.append($('<span class="icon-plus-circled">' + (selectedForTypetags.length - numberDisplayed) + '</span>'));
+    }
+
+    $('#TypetagsOption').show();
+}
+
+// close the popin
+$('.CloseTypetagsOption').each((n, elem) => $(elem).click(() => {
+    closeTypetagsOption();
+}));
+
+// when the user click on a color in the popin, allow him to validate his choice and change colors of tag's icons
+$('#TypetagsOption .color-option input').each(
+    (n, input) => $(input).bind('change', () => {
+        onColorClick();
+    }
+))
+
+function onColorClick() {
+    $('#TypetagsValidate').removeClass('disabled');
+    let selectedId = $('.color-option-container input:checked').val();
+    let option = $('.color-option[data-id=' + selectedId + ']');
+    let style = selectedId == 0 ? '' : 'color:' + option.attr('data-color');
+    $('.typetags-tags-container .icon-tags').each((n, icon) => icon.style = style);
+}
+
+// when the user validate his choice slice request in max 996 tags information and send it
+$('#TypetagsValidate').click(() => {
+    if ($('#TypetagsValidate.loading, #TypetagsValidate.disabled').length == 1) return;
+
+    $('#TypetagsValidate').addClass('loading');
+    const selectedTypeId = parseInt($('.color-option-container input:checked').val());
+    const promises = [];
+    const nbSlice = 996;
+
+    // Slice requests in max 1000 array size
+    for (let i = 0; i < selectedForTypetags.length; i += nbSlice) {
+        promises.push(
+            APIUpdateColorsTags(
+                selectedForTypetags.slice(i, Math.min(i + nbSlice,selectedForTypetags.length)),
+                selectedTypeId
+            )
+        );
+    }
+
+    Promise.all(promises)
+    .then(() => {
+        $('.typetags-actions .typetag-message').show();
+        // change tagColor
+        let typeTag = {
+            id_typetags: (selectedTypeId == 0) ? null : selectedTypeId,
+            color: (selectedTypeId == 0) ? null : typeOfTags[selectedTypeId].color,
+        };
+        selectedForTypetags.forEach(id => {
+            tagColor[id] = typeTag;
+        });
+
+        // update new color
+        updateTagsColor(getIdsSelectedOnPage())
+            .then(() => {
+                $('#TypetagsValidate').removeClass('loading');
+            })
+
+        typetagsHasValidate = true;
+    })
+    .catch(e => console.error(e));
+});
+
+$('#TypetagsCreate').click(() => {
+    APICreateColor(
+        $('#TypetagName').val(),
+        $('#TypetagColor').val().slice(1,7) // remove the #
+    )
+    .then(data => {
+        if (data.stat == 'ok') {
+            $('.typetags-create-actions .typetag-error').hide();
+            $('.typetags-create-actions .typetag-message').show();
+            addColorOption(data.result)
+        } else {
+            let str_error = data.message;
+            if (data.err == 1002)
+                str_error = str_missing_field;
+            else if (data.message == 'Invalid color')
+                str_error = str_invalid_color;
+            else if (data.message == 'This name is already used')
+                str_error = str_name_used;
+
+            $('.typetags-create-actions .typetag-message').hide();
+            $('.typetags-create-actions .typetag-error').html(str_error);
+            $('.typetags-create-actions .typetag-error').show();
+        }
+    })
+    .catch(e => console.error(e));
+})
+
+function addColorOption(typetag) {
+    const newOption = $('.color-option[data-id=n]').clone();
+    newOption.attr('data-id', typetag.id);
+    newOption.attr('data-color', typetag.color);
+    newOption.attr('title', typetag.color);
+
+    newOption.find('input').bind('change',onColorClick);
+    newOption.find('input').attr('value', typetag.id);
+    newOption.find('input').attr('id', 'tag-color-' + typetag.id);
+
+    newOption.find('label').attr('for', 'tag-color-' + typetag.id);
+
+    newOption.find('.color-name').html(typetag.name);
+
+    newOption.find('label').css({ 'border-color': typetag.color, 'background': typetag.color });
+    newOption.find('.color-sample').css({ 'background': typetag.color });
+    newOption.find('.color-sample i').css({ 'color': typetag.color });
+    newOption.find('.color-name').css({ 'color': typetag.color_text });
+    
+    typeOfTags[typetag.id] = typetag;
+
+    $('.color-option-container').append(newOption);
+}
+
+// when the popin closes, reset the popin and if the user change a color deselect tags
+function closeTypetagsOption() {
+    $('#TypetagsOption').hide();
+    if ($('.color-option-container input:checked').length != 0)
+        $('.color-option-container input:checked')[0].checked = false
+    $('#TypetagsValidate').addClass('disabled');
+    $('.typetag-error, .typetag-message').hide();
+    if (typetagsHasValidate) {
+        // clear selection
+        clearSelection();
+        $(".tag-box").attr("data-selected", '0');
+        typetagsHasValidate = false;
+        $('.tag-select-message').slideUp();
+    }
+};
+
+// call the api for change a color
+function APIUpdateColorsTags(tagIds, typeId) {
+    return new Promise((res, rej) => {
+        jQuery.ajax({
+            url: 'ws.php?format=json',
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                method: 'typetags.tags.setType',
+                tag_id: tagIds,
+                typetag_id: typeId,
+            },
+            success: function (data) {
+                res(data);
+            },
+            error: function (message) {
+                rej(message);
+            }
+        })
+    })
+}
+
+// call the api to create a color 
+function APICreateColor(name, color) {
+    return new Promise((res, rej) => {
+        jQuery.ajax({
+            url: 'ws.php?format=json',
+            type: 'GET',
+            dataType: 'json',
+            data: {
+                method: 'typetags.type.add',
+                typetag_name: name,
+                typetag_color: color,
+            },
+            success: function (data) {
+                res(data);
+            },
+            error: function (message) {
+                rej(message);
+            }
+        })
+    })
+}
+
+
+// Here, we will do what's called a pro gamer move : 
+// To update the color on page change, we save updatePage in realUpdatePage and redefine updatePage
+// Then, in the newly defined updatePage, we call realUpdatePage and wait it's done for update colors (and return a promise)
+
+var realUpdatePage = updatePage;
+
+updatePage = function() {
+    return new Promise(res => {
+        realUpdatePage()
+        .then(async () => {
+            await updateTagsColor(getIdsOnPage());
+            res()
+        })
+    })
+}

--- a/template/tags.tpl
+++ b/template/tags.tpl
@@ -1,142 +1,87 @@
-{if isset($TYPETAGS_LIST)}
 {combine_script id="farbtastic" require="jquery" path=$TYPETAGS_PATH|cat:"template/farbtastic/farbtastic.js"}
 {combine_css id="farbastic" path=$TYPETAGS_PATH|cat:"template/farbtastic/farbtastic.css"}
 {combine_css path=$TYPETAGS_PATH|cat:"template/style.css"}
+{combine_script id='typetags' load='footer' require="jquery" path=$TYPETAGS_PATH|cat:'template/tags.js'}
 
-{footer_script}
-(function($){
-  var $error = $('#colorpicker-container .error'),
-      $info = $('#colorpicker-container .info'),
-      $all_select = $('select[name^=tag_color]');
+<script>
+  {literal}
 
-  var typetags_names = [{strip}
-    {foreach from=$typetags item=typetag name=loop}
-      {if !$smarty.foreach.loop.first},{/if}
-      '{$typetag.name|escape:javascript}'
-    {/foreach}
-  {/strip}];
+  const typeOfTags = {};
 
-  function checkColor(color) {
-    if (color[0] == '#') {
-      color = color.substr(1);
-    }
+  {/literal}
 
-    if (color.length == 3) {
-      color = color[0]+color[0]+color[1]+color[1]+color[2]+color[2];
-    }
-    else if (color.length != 6 || isNaN(parseInt(color, 16))) {
-      return false;
-    }
+  JSON.parse('{json_encode($typetags)}').forEach(el => typeOfTags[el.id] = el);
+  const tagColor = {strip} JSON.parse('{json_encode($tags_color)}');{/strip}
 
-    return '#'+color;
-  }
+  const str_name_used = "{'This name is already used'|translate|escape:javascript}";
+  const str_invalid_color = "{'Invalid color'|translate|escape:javascript}";
+  const str_missing_field = "{'You must fill all fields (name and color)'|translate|escape:javascript}";
 
-  function duplicateStyle($from, $to) {
-    $to.attr('style', $from.attr('style'));
-  }
+</script>
 
+<div id="TypetagsOption" class="UserListPopIn" style="display: none;"> {* Use the style of the popin in the group manager*}
+  <div id="TypetagsPopin" class="UserListPopInContainer">
+    <a class="icon-cancel CloseUserList CloseTypetagsOption"></a>
+    <div class="popin-title"> <span class="icon icon-brush"></span> <span class='title'>Colored Tags</span></div>
 
-  // init select and first option with an explicit style attribute
-  $all_select.find('option:first-child').attr('style', 'color:'+ $all_select.css('color') +';background:'+ $all_select.css('background-color') +';');
+    <div class="typetags-tags">
+      <span class="typetags-tags-container"></span>
+    </div>
 
-  // change select color on change
-  $all_select.on('change', function() {
-    duplicateStyle($(this).find(':selected'), $(this));
-    $('input[name=mode]').prop('checked', false).filter('[value='+ $(this).data('mode') +']').prop('checked', true);
-  });
+    <div class="typetags-main-container">
+      <div class="typetags-color-choose">
+        <p>{'Set tags color'|translate}</p>
+        <div class="color-option-container">
+          <div class="color-option" data-id="n" title="No Color">
+              <input type="radio" id="tag-color-n" name="typetags" value=0 style="display: none;">
+              <label for="tag-color-n" style="border-color:black; background: black">
+                  <span class="color-sample" style="background:black"><i class="icon-ok" style="color:black"></i></span>
+                  <span class="color-name" style="color:white">{'Remove color'|translate}</span>
+              </label>
+          </div>
+        {foreach from=$typetags item=typetag}
+          <div class="color-option" data-id={$typetag.id} data-color="{$typetag.color}" title="{$typetag.color}">
+              <input type="radio" id="tag-color-{$typetag.id}" value={$typetag.id} name="typetags" style="display: none;">
+              <label for="tag-color-{$typetag.id}" style="border-color:{$typetag.color};background:{$typetag.color}">
+                  <span class="color-sample" style="background:{$typetag.color}">
+                    <i class="icon-ok" style="color:{$typetag.color}"></i>
+                  </span>
+                  <span class="color-name" style="color:{$typetag.color_text}">{$typetag.name}</span>
+              </label>
+          </div>
+        {/foreach}
+        </div>
+      </div>
 
-  // init colorpicker
-  $('#colorpicker').farbtastic('#hexval');
-
-  // add color
-  $('input[name=addtypetag]').on('click', function(e) {
-    e.preventDefault();
-
-    $error.hide();
-    $info.hide();
-
-    var name = $('input[name=typetag_name]').val(),
-        color = $('input[name=typetag_color]').val(),
-        color_text = $('input[name=typetag_color]').css('color');
-
-    if (name == '' || color == '') {
-      $error.show().html('{'You must fill all fields (name and color)'|translate|escape:javascript}');
-    }
-    else if (typetags_names.indexOf(name) != -1) {
-      $error.show().html('{'This name is already used'|translate|escape:javascript}');
-    }
-    else if ( (color = checkColor(color)) === false) {
-      $error.show().html('{'Invalid color'|translate|escape:javascript}');
-    }
-    else {
-      typetags_names.push(name);
-
-      $('select[name^=tag_color]').append('<option value="'+ color +'|'+ name +'" style="color:'+ color_text +';background:'+ color +';">'+ name +' ('+ color +')</option>');
-
-      $('input[name=typetag_name]').val(''),
-      $('input[name=typetag_color]').val('#444444').trigger('keyup');
-      $info.show().html('{'Color added'|translate|escape:javascript}');
-    }
-  });
-}(jQuery));
-{/footer_script}
-
-
-<fieldset>
-  <legend>{'Set tags color'|translate}</legend>
-  <input type="hidden" name="edit_list" value="{$TYPETAGS_LIST}">
-
-  <fieldset id="colorpicker-container">
-    <legend>{'Add a new color'|translate}</legend>
-
-    <div id="colorpicker"></div>
-    <p>&nbsp;</p>
-    <p>{'Name'|translate} : <input type="text" size="18" name="typetag_name"></p>
-    <p>{'Color'|translate} : <input type="text" id="hexval" name="typetag_color" size="7" maxlength="7" value="#444444"></p>
-    <p>
-      <span class="error"></span> <span class="info"></span><br>
-      <input class="submit" type="submit" name="addtypetag" value="{'Add'|translate}">
-    </p>
-  </fieldset>
-
-  <p>
-    <label><input type="radio" name="mode" value="global"> {'Apply the same color to all tags'|translate}</label>
-
-    <select name="tag_color-all" style="" data-mode="global">
-      <option value="-1" style="" selected>{'None'|translate}</option>
-    {foreach from=$typetags item=typetag}
-      <option value="~~{$typetag.id}~~" style="color:{$typetag.color_text};background:{$typetag.color};">{$typetag.name} ({$typetag.color})</option>
-    {/foreach}
-    </select>
-  </p>
-
-  <p>
-    <label><input type="radio" name="mode" value="unit" checked> {'Set a different color for each tag'|translate}</label>
-
-    <table class="table2" style="margin:0;">
-      <tr class="throw">
-        <th>{'Tag'|translate}</th>
-        <th>{'New color'|translate}</th>
-      </tr>
-    {foreach from=$tags item=tag}
-      <tr>
-        <td>{$tag.name}</td>
-        <td>
-          <select name="tag_color-{$tag.id}" style="color:{$tag.color_text};background:{$tag.color};" data-mode="unit">
-            <option value="-1" style="">{'None'|translate}</option>
-          {foreach from=$typetags item=typetag}
-            <option value="~~{$typetag.id}~~" style="color:{$typetag.color_text};background:{$typetag.color};" {if $tag.id_typetags==$typetag.id}selected{/if}>{$typetag.name} ({$typetag.color})</option>
-          {/foreach}
-          </select>
-        </td>
-      </tr>
-    {/foreach}
-    </table>
-  </p>
-
-  <p>
-    <input type="submit" name="typetags_submit" value="{'Submit'|translate}">
-    <input type="submit" name="typetags_cancel" value="{'Cancel'|translate}">
-  </p>
-</fieldset>
-{/if}
+      <div class="typetag-color-create">
+        <p>{'Add a new color'|translate}</p>
+        <div class="typetag-color-create-container">
+          <div id="colorpicker"></div>
+          <div class="typetag-color-create-form">
+            <div class="typetags-input-container"> {* Use the style of the input in the user manager popin*}
+              <p>{'Name'|translate}</p>
+              <input type="text" size="18" id="TypetagName">
+            </div>
+            <div class="typetags-input-container">
+              <p>{'Color'|translate}</p>
+              <input type="text" id="TypetagColor" size="7" maxlength="7" value="#444444">
+            </div>
+            <div class="typetags-create-actions">
+              <span id="TypetagsCreate" class="typetag-button icon-plus">Créer</span>
+              <span class="typetag-error icon-cancel"></span>
+              <span class="typetag-message icon-ok">{'Color added'|translate}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="typetags-actions"> {* Use the style of the buttons in the user manager popin*}
+      <span id="TypetagsValidate" class="icon-ok typetag-button disabled">{'Set tags color'|translate}<i class="icon-spin6 animate-spin"></i></span> {* Use the style of the button in the user manager popin*}
+      <span class="close-button CloseTypetagsOption">{'Close'|translate}</span>
+      <span class="typetag-error icon-cancel"></span>
+      <span class="typetag-message icon-ok">{'Color saved'|translate}</span>
+    </div>
+    <span class="typetags-info">{'Go to <a href="%s">plugin page</a> to edit colors'|translate:($ROOT_URL|cat:'admin.php?page=plugin-typetags')}</span>
+  </div>
+</div>


### PR DESCRIPTION
* Add a button and a popin in the tag admin page for assign and create type (actions implemented in AJAX)
* Remove the possibility of assign different colors on the same selected tags on tag admin page
* Creation of two API routes : assign type to tags and create a new type